### PR TITLE
GameTooltip_SetBackdropStyle is not a function

### DIFF
--- a/KkthnxUI/Modules/Tooltip/Core.lua
+++ b/KkthnxUI/Modules/Tooltip/Core.lua
@@ -502,7 +502,7 @@ function Module:OnEnable()
 	hooksecurefunc("GameTooltip_ShowStatusBar", Module.GameTooltip_ShowStatusBar)
 	hooksecurefunc("GameTooltip_ShowProgressBar", Module.GameTooltip_ShowProgressBar)
 	hooksecurefunc("GameTooltip_SetDefaultAnchor", Module.GameTooltip_SetDefaultAnchor)
-	hooksecurefunc("GameTooltip_SetBackdropStyle", Module.SharedTooltip_SetBackdropStyle)
+	hooksecurefunc("SharedTooltip_SetBackdropStyle", Module.SharedTooltip_SetBackdropStyle)
 	hooksecurefunc("GameTooltip_AnchorComparisonTooltips", Module.GameTooltip_ComparisonFix)
 
 	-- Elements


### PR DESCRIPTION
fix tbc error i guess

Issue Fixed N/A

```
KkthnxUI\Modules\Tooltip\Core.lua:505: hooksecurefunc(): GameTooltip_SetBackdropStyle is not a function
[string "=[C]"]: ?
[string "@KkthnxUI\Modules\Tooltip\Core.lua"]:505: in function `OnEnable'
[string "@KkthnxUI\Init.lua"]:270: in function `func'
[string "@KkthnxUI\Init.lua"]:164: in function <KkthnxUI\Init.lua:159>
```

## Proposed Changes

- Change `GameTooltip` to `SharedTooltip`. Not sure if this works fully but it stops the error for me.

@Kkthnx-WoW
